### PR TITLE
feat: add /new command to start a fresh chat session

### DIFF
--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -12,11 +12,12 @@ type commandInfo struct {
 }
 
 var allCommands = []commandInfo{
+	{"help", "list available commands"},
+	{"new", "start a fresh conversation"},
 	{"model", "switch active model"},
 	{"cost", "show session cost and token usage"},
 	{"compact", "compact conversation history"},
 	{"resume", "list and reopen a previous conversation"},
-	{"help", "list available commands"},
 }
 
 func parseCommand(input string) (command, bool) {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -786,9 +786,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case "new":
 					m.resetSession()
 				case "resume":
-					if m.streaming || m.compacting {
-						return m, nil
-					}
 					m.openSessionsPicker()
 					return m, nil
 				case "help":

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -165,10 +165,14 @@ func New(cfg *config.Config, client *llm.Client, currentModel string, state Stat
 		initCmd:      focusCmd,
 		streamBuf:    &strings.Builder{},
 		compactBuf:   &strings.Builder{},
-		conversation: sessions.Conversation{
-			Messages: []sessions.Message{
-				{Role: sessions.RoleSystem, Content: defaultSystemPrompt},
-			},
+		conversation: newConversation(),
+	}
+}
+
+func newConversation() sessions.Conversation {
+	return sessions.Conversation{
+		Messages: []sessions.Message{
+			{Role: sessions.RoleSystem, Content: defaultSystemPrompt},
 		},
 	}
 }
@@ -450,11 +454,7 @@ func (m *Model) resetSession() {
 		m.autosave()
 	}
 	m.messages = m.messages[:0]
-	m.conversation = sessions.Conversation{
-		Messages: []sessions.Message{
-			{Role: sessions.RoleSystem, Content: defaultSystemPrompt},
-		},
-	}
+	m.conversation = newConversation()
 	m.sessionID = ""
 	m.sessionCreatedAt = time.Time{}
 	m.refreshViewport()
@@ -784,9 +784,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case "compact":
 					return m, m.startCompact()
 				case "new":
-					if m.streaming || m.compacting {
-						return m, nil
-					}
 					m.resetSession()
 				case "resume":
 					if m.streaming || m.compacting {

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -445,6 +445,22 @@ func (m *Model) applySession(s *sessions.Session) {
 	m.viewport.GotoBottom()
 }
 
+func (m *Model) resetSession() {
+	if len(m.conversation.Messages) > 1 {
+		m.autosave()
+	}
+	m.messages = m.messages[:0]
+	m.conversation = sessions.Conversation{
+		Messages: []sessions.Message{
+			{Role: sessions.RoleSystem, Content: defaultSystemPrompt},
+		},
+	}
+	m.sessionID = ""
+	m.sessionCreatedAt = time.Time{}
+	m.refreshViewport()
+	m.viewport.GotoTop()
+}
+
 func (m *Model) selectModel(id string) {
 	m.currentModel = id
 	m.state.touch(id)
@@ -767,6 +783,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.costActive = true
 				case "compact":
 					return m, m.startCompact()
+				case "new":
+					if m.streaming || m.compacting {
+						return m, nil
+					}
+					m.resetSession()
 				case "resume":
 					if m.streaming || m.compacting {
 						return m, nil


### PR DESCRIPTION
Closes #8

## Summary

- Adds `/new` slash command that resets the session in-place (clears messages, rebuilds the conversation with only the default system prompt, clears `sessionID`/`sessionCreatedAt` so the next message autosaves to a new session file).
- Blocks while a stream or compact is in progress — user must `ctrl+c` first. Mirrors the cautious behavior of `/resume`.
- Calls `autosave()` defensively before clearing if there is anything beyond the system prompt, covering the gap where a user message can sit in memory without having been persisted (e.g. previous turn errored before any tokens streamed).
- Registers `/new` in `allCommands` so it appears in `/help`. Reordered to `help, new, model, cost, compact, resume`.

## Cleanups bundled in

- Extracted a small `newConversation()` helper shared by `New()` and `resetSession()` to remove the duplicated default-conversation literal.
- Removed dead `if m.streaming || m.compacting { return m, nil }` guards inside `case "new":` and `case "resume":` — the outer `case "enter":` already returns early on the same condition before the inner switch is reached.

## Follow-up (separate issue worth opening)

The autosave invariant "in memory ⊆ on disk" is leaky: error / cancel-empty paths in the streaming code (ui.go ~518–533, 556–576) don't autosave, leaving orphan user messages. The defensive `autosave()` in `resetSession` papers over the `/new` case but doesn't fix the root cause.

## Test plan

- [ ] `/help` lists `/new` in the new ordering
- [ ] `/new` on a fresh session is a no-op visually (already empty)
- [ ] `/new` after a few turns clears the viewport and starts fresh; next message creates a new session file (visible in `/resume`)
- [ ] `/new` while streaming is silently ignored; `ctrl+c` then `/new` works
- [ ] After a stream error with no tokens, `/new` persists the orphan user message before clearing (verifiable via `/resume`)