### PR TITLE
fix(ui): autosave on stream start/event error paths to preserve orphan user messages (#11)

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -460,9 +460,11 @@ func (m *Model) applySession(s *sessions.Session) {
 }
 
 func (m *Model) resetSession() {
-	if len(m.conversation.Messages) > 1 {
-		m.autosave()
-	}
+	// The stream-start and stream-event error paths now autosave
+	// directly, so the defensive autosave that used to live here
+	// (PR #10) is no longer needed — the "if it's in
+	// m.conversation.Messages, it's on disk" invariant holds before
+	// we get here.
 	m.messages = m.messages[:0]
 	m.conversation = newConversation(m.cfg.SystemPrompt)
 	m.currentSession = nil
@@ -615,6 +617,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.op.cancel()
 			}
 			m.resetOp()
+			// The user message was appended to m.conversation.Messages
+			// before the stream started. If the stream then fails to
+			// start, no autosave path fires — leaving the user message
+			// in memory only. Persist it now so it survives /new or a
+			// process exit (issue #11).
+			if len(m.conversation.Messages) > 1 {
+				m.autosave()
+			}
 			if cancelled {
 				m.messages = append(m.messages, message{role: roleInfo, content: "Compact cancelled."})
 				m.refreshViewport()
@@ -655,6 +665,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.resetOp()
 			} else {
 				m.finalizeStream()
+			}
+			// finalizeStream only autosaves when streamBuf is non-empty,
+			// so an error before any token arrived leaves the pending
+			// user message in memory only. Persist it now so /new or a
+			// crash doesn't drop it (issue #11).
+			if m.op.kind != opCompact && len(m.conversation.Messages) > 1 {
+				m.autosave()
 			}
 			if cancelled {
 				m.messages = append(m.messages, message{role: roleInfo, content: "Compact cancelled."})

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -24,7 +24,7 @@ const (
 	compactPrompt = "You are summarizing this conversation so it can be continued with less context. " +
 		"Preserve: the user's underlying goal, key facts and decisions, any code or concrete details referenced, " +
 		"and any open questions or pending actions. Drop: pleasantries, tangents, and verbose explanations that " +
-		"have already been acknowledged. Respond with the summary only — no preamble, no meta-commentary."
+		"have already been acknowledged. Respond with the summary only, no preamble, no meta-commentary."
 )
 
 type modelsLoadedMsg struct {
@@ -80,7 +80,7 @@ const (
 
 // activeOp holds the state of an in-flight LLM operation. Streaming and
 // compacting are mutually exclusive, so they share buffer, channel, cancel and
-// cancelled flag — kind discriminates which one is active.
+// cancelled flag, kind discriminates which one is active.
 type activeOp struct {
 	kind      opKind
 	buf       *strings.Builder
@@ -462,7 +462,7 @@ func (m *Model) applySession(s *sessions.Session) {
 func (m *Model) resetSession() {
 	// The stream-start and stream-event error paths now autosave
 	// directly, so the defensive autosave that used to live here
-	// (PR #10) is no longer needed — the "if it's in
+	// (PR #10) is no longer needed, the "if it's in
 	// m.conversation.Messages, it's on disk" invariant holds before
 	// we get here.
 	m.messages = m.messages[:0]
@@ -550,7 +550,7 @@ func (m *Model) finalizeCompact() {
 	}
 	summary := sessions.Message{
 		Role: sessions.RoleAssistant,
-		Content: "[Conversation summary — condensed history of earlier turns]\n" +
+		Content: "[Conversation summary, condensed history of earlier turns]\n" +
 			m.op.buf.String() +
 			"\n[End of summary]",
 		Model: m.currentModel,
@@ -619,7 +619,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.resetOp()
 			// The user message was appended to m.conversation.Messages
 			// before the stream started. If the stream then fails to
-			// start, no autosave path fires — leaving the user message
+			// start, no autosave path fires, leaving the user message
 			// in memory only. Persist it now so it survives /new or a
 			// process exit (issue #11).
 			if len(m.conversation.Messages) > 1 {


### PR DESCRIPTION
## Summary

The user message is appended to `m.conversation.Messages` before the stream starts, but `autosave()` was only reachable via `finalizeStream` (gated on `m.streamBuf.Len() > 0`) and `finalizeCompact`. If the stream failed to start (network/auth error) or errored before any token arrived, the user message lived in memory only and was silently lost by `/new`, a subsequent send, or a process exit.

## Fix

- Call `autosave()` on the `streamStartMsg.err != nil` branch before `addError`, when the conversation has content beyond the system prompt.
- Call `autosave()` on the `streamEventMsg.Err != nil` branch after `finalizeStream` (which can't save an empty `streamBuf`) for the same condition.
- Remove the defensive `autosave()` in `resetSession()` added in PR #10, the invariant *"if it's in `m.conversation.Messages`, it's on disk"* now holds globally, so the band-aid is redundant.

Fixes #11

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`, package has no test files; build is the only automated gate
- [x] Manually traced both error handlers to confirm the `len(m.conversation.Messages) > 1` guard matches the existing `resetSession` pattern (skip system-prompt-only conversations)