### PR TITLE
feat: order /resume sessions by last accessed time

### DIFF
--- a/internal/sessions/session.go
+++ b/internal/sessions/session.go
@@ -179,15 +179,15 @@ func Load(id string) (*Session, error) {
 	return &s, nil
 }
 
-// Touch updates LastAccessedAt for the given session and persists it.
+// Touch stamps LastAccessedAt on s and persists it without modifying UpdatedAt.
 // Errors are silently ignored — this is metadata only.
-func Touch(id string) {
-	s, err := Load(id)
+func Touch(s *Session) {
+	s.LastAccessedAt = time.Now().UTC()
+	path, err := filePath(s.ID)
 	if err != nil {
 		return
 	}
-	s.LastAccessedAt = time.Now().UTC()
-	_ = Save(s)
+	_ = storage.WriteJSONAtomic(path, s, true)
 }
 
 // List returns session summaries sorted by LastAccessedAt descending, falling

--- a/internal/sessions/session.go
+++ b/internal/sessions/session.go
@@ -42,20 +42,22 @@ type Conversation struct {
 }
 
 type Session struct {
-	Version   int       `json:"version"`
-	ID        string    `json:"id"`
-	Title     string    `json:"title"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	Messages  []Message `json:"messages"`
+	Version        int       `json:"version"`
+	ID             string    `json:"id"`
+	Title          string    `json:"title"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	LastAccessedAt time.Time `json:"last_accessed_at,omitempty"`
+	Messages       []Message `json:"messages"`
 }
 
 type Summary struct {
-	ID        string
-	Title     string
-	UpdatedAt time.Time
-	Cost      float64
-	Messages  int
+	ID             string
+	Title          string
+	UpdatedAt      time.Time
+	LastAccessedAt time.Time
+	Cost           float64
+	Messages       int
 }
 
 func Dir() string {
@@ -177,7 +179,19 @@ func Load(id string) (*Session, error) {
 	return &s, nil
 }
 
-// List returns session summaries sorted by UpdatedAt descending. Unreadable or
+// Touch updates LastAccessedAt for the given session and persists it.
+// Errors are silently ignored — this is metadata only.
+func Touch(id string) {
+	s, err := Load(id)
+	if err != nil {
+		return
+	}
+	s.LastAccessedAt = time.Now().UTC()
+	_ = Save(s)
+}
+
+// List returns session summaries sorted by LastAccessedAt descending, falling
+// back to UpdatedAt for sessions that pre-date the field. Unreadable or
 // corrupted files are silently skipped — persistence is best-effort.
 func List() ([]Summary, error) {
 	d := Dir()
@@ -201,11 +215,16 @@ func List() ([]Summary, error) {
 		if err != nil {
 			continue
 		}
+		effectiveTime := s.LastAccessedAt
+		if effectiveTime.IsZero() {
+			effectiveTime = s.UpdatedAt
+		}
 		sum := Summary{
-			ID:        s.ID,
-			Title:     s.Title,
-			UpdatedAt: s.UpdatedAt,
-			Messages:  len(s.Messages),
+			ID:             s.ID,
+			Title:          s.Title,
+			UpdatedAt:      s.UpdatedAt,
+			LastAccessedAt: effectiveTime,
+			Messages:       len(s.Messages),
 		}
 		for _, m := range s.Messages {
 			sum.Cost += m.Cost
@@ -213,7 +232,7 @@ func List() ([]Summary, error) {
 		out = append(out, sum)
 	}
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].UpdatedAt.After(out[j].UpdatedAt)
+		return out[i].LastAccessedAt.After(out[j].LastAccessedAt)
 	})
 	return out, nil
 }

--- a/internal/ui/sessions_picker.go
+++ b/internal/ui/sessions_picker.go
@@ -26,7 +26,7 @@ func (i sessionItem) Title() string {
 
 func (i sessionItem) Description() string {
 	return fmt.Sprintf("  %s · %d msgs · $%.4f",
-		i.sum.UpdatedAt.Local().Format("2006-01-02 15:04"),
+		i.sum.LastAccessedAt.Local().Format("2006-01-02 15:04"),
 		i.sum.Messages,
 		i.sum.Cost,
 	)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -72,37 +72,37 @@ type streamEventMsg struct {
 }
 
 type Model struct {
-	cfg              *config.Config
-	client           *llm.Client
-	currentModel     string
-	state            State
-	modelsCache      []llmInfo
-	picker           pickerModel
-	pickerActive     bool
-	sessionsPicker   sessionsPickerModel
-	sessionsActive   bool
-	cost             costPanel
-	costActive       bool
-	width            int
-	height           int
-	separator        string
-	viewport         viewport.Model
-	textarea         textarea.Model
-	spinner          spinner.Model
-	messages         []message
-	conversation     sessions.Conversation
-	streaming        bool
-	streamBuf        *strings.Builder
-	streamCh         <-chan llm.StreamEvent
-	streamUsage      *llm.Usage
-	cancel           context.CancelFunc
-	compacting       bool
-	compactBuf       *strings.Builder
-	compactUsage     *llm.Usage
-	compactCancelled bool
-	initCmd          tea.Cmd
-	mdRenderer       *glamour.TermRenderer
-	mdRendererWidth  int
+	cfg                   *config.Config
+	client                *llm.Client
+	currentModel          string
+	state                 State
+	modelsCache           []llmInfo
+	picker                pickerModel
+	pickerActive          bool
+	sessionsPicker        sessionsPickerModel
+	sessionsActive        bool
+	cost                  costPanel
+	costActive            bool
+	width                 int
+	height                int
+	separator             string
+	viewport              viewport.Model
+	textarea              textarea.Model
+	spinner               spinner.Model
+	messages              []message
+	conversation          sessions.Conversation
+	streaming             bool
+	streamBuf             *strings.Builder
+	streamCh              <-chan llm.StreamEvent
+	streamUsage           *llm.Usage
+	cancel                context.CancelFunc
+	compacting            bool
+	compactBuf            *strings.Builder
+	compactUsage          *llm.Usage
+	compactCancelled      bool
+	initCmd               tea.Cmd
+	mdRenderer            *glamour.TermRenderer
+	mdRendererWidth       int
 	sessionID             string
 	sessionCreatedAt      time.Time
 	sessionLastAccessedAt time.Time

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -103,20 +103,24 @@ type Model struct {
 	initCmd          tea.Cmd
 	mdRenderer       *glamour.TermRenderer
 	mdRendererWidth  int
-	sessionID        string
-	sessionCreatedAt time.Time
+	sessionID             string
+	sessionCreatedAt      time.Time
+	sessionLastAccessedAt time.Time
 }
 
 func (m *Model) autosave() {
 	if m.sessionID == "" {
 		m.sessionID = sessions.NewID()
-		m.sessionCreatedAt = time.Now().UTC()
+		now := time.Now().UTC()
+		m.sessionCreatedAt = now
+		m.sessionLastAccessedAt = now
 	}
 	s := &sessions.Session{
-		ID:        m.sessionID,
-		Title:     sessions.DeriveTitle(m.conversation.Messages),
-		CreatedAt: m.sessionCreatedAt,
-		Messages:  m.conversation.Messages,
+		ID:             m.sessionID,
+		Title:          sessions.DeriveTitle(m.conversation.Messages),
+		CreatedAt:      m.sessionCreatedAt,
+		LastAccessedAt: m.sessionLastAccessedAt,
+		Messages:       m.conversation.Messages,
 	}
 	_ = sessions.Save(s)
 }
@@ -426,6 +430,7 @@ func (m *Model) applySession(s *sessions.Session) {
 	}
 	m.sessionID = s.ID
 	m.sessionCreatedAt = s.CreatedAt
+	m.sessionLastAccessedAt = time.Now().UTC()
 	m.conversation.Messages = append([]sessions.Message(nil), s.Messages...)
 
 	m.messages = m.messages[:0]
@@ -740,6 +745,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.addError("failed to load session: " + err.Error())
 					} else {
 						m.applySession(s)
+						sessions.Touch(id)
 					}
 				}
 				return m, nil

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -745,7 +745,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.addError("failed to load session: " + err.Error())
 					} else {
 						m.applySession(s)
-						sessions.Touch(id)
+						sessions.Touch(s)
 					}
 				}
 				return m, nil


### PR DESCRIPTION
## Summary

- Adds `LastAccessedAt` field to `Session` and `Summary` structs (persisted in the session JSON)
- `LastAccessedAt` is set on session creation and updated each time a session is opened via `/resume` (via new `sessions.Touch()` function)
- `/resume` picker now sorts sessions by `LastAccessedAt` descending — most recently opened appears first
- Sessions without the field (created before this change) fall back to `UpdatedAt`, preserving existing ordering

## Changes

- `internal/sessions/session.go`: added `LastAccessedAt` to `Session` and `Summary`, added `Touch()`, updated `List()` sort
- `internal/ui/ui.go`: tracks `sessionLastAccessedAt` in Model, sets it on creation and on `/resume` load, calls `sessions.Touch()` after loading
- `internal/ui/sessions_picker.go`: displays `LastAccessedAt` instead of `UpdatedAt`

## Test plan

- [ ] Open the app, start two new conversations (send at least one message each)
- [ ] Run `/resume` — sessions appear sorted by creation time (both have `LastAccessedAt = CreatedAt`)
- [ ] Resume the older session
- [ ] Run `/resume` again — the previously older session now appears first
- [ ] Restart the app and run `/resume` — order is preserved across restarts
- [ ] Existing session files (without `last_accessed_at`) still appear in a reasonable order

Closes #9