### PR TITLE
feat: add customizable system prompt via config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Launch with `llm-chat`. Type a message and press Enter to send. Alt+Enter insert
 Slash commands:
 
 ```
+/new       start a fresh conversation
 /model     switch the active model
 /cost      show session cost and token usage
 /compact   compact conversation history

--- a/config.toml.example
+++ b/config.toml.example
@@ -3,3 +3,9 @@ api_key = ""
 
 # Model to use (optional, defaults to openai/gpt-4o-mini)
 # default_model = "openai/gpt-4o-mini"
+
+# System prompt (optional)
+# system_prompt = """
+# Line one of the prompt.
+# Line two of the prompt.
+# """

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,12 +12,15 @@ import (
 
 const HardcodedDefaultModel = "openai/gpt-4o-mini"
 
+const DefaultSystemPrompt = "You are a helpful assistant."
+
 // ErrFirstRun is returned when no config file exists and a template was created.
 var ErrFirstRun = errors.New("first run")
 
 type Config struct {
 	APIKey       string `toml:"api_key"`
 	DefaultModel string `toml:"default_model"`
+	SystemPrompt string `toml:"system_prompt"`
 }
 
 func ConfigPath() string {
@@ -30,6 +33,12 @@ api_key = ""
 
 # Model to use (optional, defaults to openai/gpt-4o-mini)
 # default_model = "openai/gpt-4o-mini"
+
+# System prompt (optional)
+# system_prompt = """
+# Line one of the prompt.
+# Line two of the prompt.
+# """
 `
 
 func Load() (*Config, error) {
@@ -63,5 +72,9 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("api_key is required. Set it in %s", path)
 	}
 	cfg.DefaultModel = strings.TrimSpace(cfg.DefaultModel)
+	cfg.SystemPrompt = strings.TrimSpace(cfg.SystemPrompt)
+	if cfg.SystemPrompt == "" {
+		cfg.SystemPrompt = DefaultSystemPrompt
+	}
 	return &cfg, nil
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	defaultSystemPrompt = "You are a helpful assistant."
-	compactPrompt       = "You are summarizing this conversation so it can be continued with less context. " +
+	compactPrompt = "You are summarizing this conversation so it can be continued with less context. " +
 		"Preserve: the user's underlying goal, key facts and decisions, any code or concrete details referenced, " +
 		"and any open questions or pending actions. Drop: pleasantries, tangents, and verbose explanations that " +
 		"have already been acknowledged. Respond with the summary only — no preamble, no meta-commentary."
@@ -169,14 +168,14 @@ func New(cfg *config.Config, client *llm.Client, currentModel string, state Stat
 		initCmd:      focusCmd,
 		streamBuf:    &strings.Builder{},
 		compactBuf:   &strings.Builder{},
-		conversation: newConversation(),
+		conversation: newConversation(cfg.SystemPrompt),
 	}
 }
 
-func newConversation() sessions.Conversation {
+func newConversation(systemPrompt string) sessions.Conversation {
 	return sessions.Conversation{
 		Messages: []sessions.Message{
-			{Role: sessions.RoleSystem, Content: defaultSystemPrompt},
+			{Role: sessions.RoleSystem, Content: systemPrompt},
 		},
 	}
 }
@@ -432,6 +431,7 @@ func (m *Model) applySession(s *sessions.Session) {
 	m.sessionCreatedAt = s.CreatedAt
 	m.sessionLastAccessedAt = time.Now().UTC()
 	m.conversation.Messages = append([]sessions.Message(nil), s.Messages...)
+	m.conversation.Messages[0].Content = m.cfg.SystemPrompt
 
 	m.messages = m.messages[:0]
 	for _, dm := range s.Messages {
@@ -459,7 +459,7 @@ func (m *Model) resetSession() {
 		m.autosave()
 	}
 	m.messages = m.messages[:0]
-	m.conversation = newConversation()
+	m.conversation = newConversation(m.cfg.SystemPrompt)
 	m.sessionID = ""
 	m.sessionCreatedAt = time.Time{}
 	m.refreshViewport()


### PR DESCRIPTION
## Summary

- Adds optional `system_prompt` field to `config.toml`. When unset or whitespace-only, falls back to `DefaultSystemPrompt` (`"You are a helpful assistant."`).
- New sessions (app startup and `/new`) seed `Messages[0]` with `cfg.SystemPrompt`.
- On `/resume`, the loaded `Messages[0]` is overwritten with the current `cfg.SystemPrompt` — config at runtime always wins, consistent with #4. Persists naturally on the next `Save()`.
- Updates `config.toml.example` and the first-run `templateConfig` with a commented multi-line example.
- Non-breaking: existing `config.toml` files and saved sessions keep working without modification.

Closes #5

## Test plan

- [ ] With no `system_prompt` in config, behavior matches the previous default ("helpful assistant").
- [ ] With a custom `system_prompt`, new sessions reflect the persona.
- [ ] `/new` after editing the config seeds the new conversation with the configured prompt.
- [ ] `/resume` on an old session overrides `Messages[0]` with the current config's prompt — verified by both runtime behavior and the persisted JSON after the next turn.
- [ ] `system_prompt = ""` (or whitespace) falls back to the default.
- [ ] First-run with no config writes the template containing the commented `system_prompt` block.
- [ ] Existing sessions saved without `LastAccessedAt` etc. still resume cleanly.